### PR TITLE
Updated packages

### DIFF
--- a/src/Reddoxx.Quartz.MongoDbJobStore/Reddoxx.Quartz.MongoDbJobStore.csproj
+++ b/src/Reddoxx.Quartz.MongoDbJobStore/Reddoxx.Quartz.MongoDbJobStore.csproj
@@ -29,10 +29,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-		<PackageReference Include="MongoDB.Driver" Version="2.27.0" />
-		<PackageReference Include="Quartz" Version="3.11.0" />
-		<PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.11.0" />
-		<PackageReference Include="Quartz.Serialization.SystemTextJson" Version="3.11.0" />
+		<PackageReference Include="MongoDB.Driver" Version="2.28.0" />
+		<PackageReference Include="Quartz" Version="3.13.0" />
+		<PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.13.0" />
+		<PackageReference Include="Quartz.Serialization.SystemTextJson" Version="3.13.0" />
 	</ItemGroup>
 
 

--- a/src/Reddoxx.Quartz.MongoDbJobStore/Reddoxx.Quartz.MongoDbJobStore.csproj
+++ b/src/Reddoxx.Quartz.MongoDbJobStore/Reddoxx.Quartz.MongoDbJobStore.csproj
@@ -29,10 +29,10 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.1" />
-		<PackageReference Include="MongoDB.Driver" Version="2.28.0" />
-		<PackageReference Include="Quartz" Version="3.13.0" />
-		<PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.13.0" />
-		<PackageReference Include="Quartz.Serialization.SystemTextJson" Version="3.13.0" />
+		<PackageReference Include="MongoDB.Driver" Version="[2.28.0,3.0)" />
+		<PackageReference Include="Quartz" Version="3.11" />
+		<PackageReference Include="Quartz.Extensions.DependencyInjection" Version="3.11" />
+		<PackageReference Include="Quartz.Serialization.SystemTextJson" Version="3.11" />
 	</ItemGroup>
 
 

--- a/tests/Reddoxx.Quartz.MongoDbJobStore.Tests/Reddoxx.Quartz.MongoDbJobStore.Tests.csproj
+++ b/tests/Reddoxx.Quartz.MongoDbJobStore.Tests/Reddoxx.Quartz.MongoDbJobStore.Tests.csproj
@@ -36,8 +36,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Quartz.AspNetCore" Version="3.11.0" />
-		<PackageReference Include="Quartz" Version="3.11.0" />
+		<PackageReference Include="Quartz.AspNetCore" Version="3.13.0" />
+		<PackageReference Include="Quartz" Version="3.13.0" />
 
 		<PackageReference Include="StackExchange.Redis.Extensions.AspNetCore" Version="10.2.0" />
 		<PackageReference Include="StackExchange.Redis.Extensions.System.Text.Json" Version="10.2.0" />


### PR DESCRIPTION
Just updated Quartz libraries to the latest version and also MongoDB.Driver (it accepts a range between 2.28 and 3.0)